### PR TITLE
Adds a HashBytes Implementation With Benchmarks and Adds Support for MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# intellij/goland project folder
+.idea

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Go version of ssdeep [http://ssdeep.sourceforge.net/].
 [2]: https://travis-ci.org/dutchcoders/gossdeep
 
 ## Installation
+Installation requires specific `CGO_LDFLAGS_ALLOW` be set before both `go get` and compilation.
+
 ```
+export CGO_LDFLAGS_ALLOW="^-[Il].*$"
 go get github.com/dutchcoders/gossdeep
 
 // use in your .go code

--- a/ssdeep.go
+++ b/ssdeep.go
@@ -1,7 +1,7 @@
 package ssdeep
 
 /*
-#cgo linux LDFLAGS:-L/usr/local/lib/ -lfuzzy -ldl -I/usr/local/include/
+#cgo !windows LDFLAGS:-L/usr/local/lib/ -lfuzzy -ldl -I/usr/local/include/
 #include <stdlib.h>
 #include <fuzzy.h>
 */
@@ -13,8 +13,7 @@ import (
 )
 
 type FuzzyState struct {
-	cstate *
-	C.struct_fuzzy_state
+	cstate *C.struct_fuzzy_state
 }
 
 /*
@@ -121,6 +120,18 @@ func HashFilename(filename string) (string, error) {
 	defer C.free(unsafe.Pointer(cf))
 
 	if C.fuzzy_hash_filename(cf, buf) != 0 {
+		return "", errors.New("")
+	}
+
+	return C.GoString(buf), nil
+}
+
+func HashBytes(b []byte) (string, error) {
+	buf := (*C.char)(C.calloc(C.FUZZY_MAX_RESULT, 1))
+	defer C.free(unsafe.Pointer(buf))
+	length := C.uint32_t(len(b))
+
+	if C.fuzzy_hash_buf((*C.uchar)(unsafe.Pointer(&b[0])), length, buf) != 0 {
 		return "", errors.New("")
 	}
 

--- a/ssdeep_test.go
+++ b/ssdeep_test.go
@@ -2,11 +2,27 @@ package ssdeep
 
 import (
 	"io/ioutil"
+	"math/rand"
 	"testing"
 )
 
 func TestHashString(t *testing.T) {
 	gotData, err := HashString("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := "3:Hn:Hn"
+	if gotData != data {
+		t.Errorf("result mismatch:\nwant: %v\n got: %v", data, gotData)
+	}
+}
+
+/*
+Obtain the fuzzy hash from the state.
+*/
+func TestHashBytes(t *testing.T) {
+	gotData, err := HashBytes([]byte("test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,4 +106,94 @@ func TestScore(t *testing.T) {
 	if gotData != data {
 		t.Errorf("score mismatch:\nwant: %v\n got: %v", data, gotData)
 	}
+}
+
+func BenchmarkSSDeepString_1k(b *testing.B) {
+	runSSDeepBenchmarkString(1024, b)
+}
+
+func BenchmarkSSDeepString_10k(b *testing.B) {
+	runSSDeepBenchmarkString(10*1024, b)
+}
+
+func BenchmarkSSDeepString_100k(b *testing.B) {
+	runSSDeepBenchmarkString(100*1024, b)
+}
+
+func BenchmarkSSDeepString_250k(b *testing.B) {
+	runSSDeepBenchmarkString(250*1024, b)
+}
+
+func BenchmarkSSDeepString_500k(b *testing.B) {
+	runSSDeepBenchmarkString(500*1024, b)
+}
+
+func BenchmarkSSDeepConvertString_1k(b *testing.B) {
+	runSSDeepBenchmarkBytes(true, 1024, b)
+}
+
+func BenchmarkSSDeepConvertString_10k(b *testing.B) {
+	runSSDeepBenchmarkBytes(true, 10*1024, b)
+}
+
+func BenchmarkSSDeepConvertString_100k(b *testing.B) {
+	runSSDeepBenchmarkBytes(true, 100*1024, b)
+}
+
+func BenchmarkSSDeepConvertString_250k(b *testing.B) {
+	runSSDeepBenchmarkBytes(true, 250*1024, b)
+}
+
+func BenchmarkSSDeepConvertString_500k(b *testing.B) {
+	runSSDeepBenchmarkBytes(true, 500*1024, b)
+}
+
+func BenchmarkSSDeepBytes_1k(b *testing.B) {
+	runSSDeepBenchmarkBytes(false, 1024, b)
+}
+
+func BenchmarkSSDeepBytes_10k(b *testing.B) {
+	runSSDeepBenchmarkBytes(false, 10*1024, b)
+}
+
+func BenchmarkSSDeepBytes_100k(b *testing.B) {
+	runSSDeepBenchmarkBytes(false, 100*1024, b)
+}
+
+func BenchmarkSSDeepBytes_250k(b *testing.B) {
+	runSSDeepBenchmarkBytes(false, 250*1024, b)
+}
+
+func BenchmarkSSDeepBytes_500k(b *testing.B) {
+	runSSDeepBenchmarkBytes(false, 500*1024, b)
+}
+
+func runSSDeepBenchmarkBytes(convertString bool, i int, b *testing.B) {
+	bs := randomBytes(i, b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if convertString {
+			HashString(string(bs))
+		}
+		HashBytes(bs)
+	}
+
+}
+
+func randomBytes(i int, b *testing.B) []byte {
+	bs := make([]byte, i)
+	_, err := rand.Read(bs)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return bs
+}
+
+func runSSDeepBenchmarkString(i int, b *testing.B) {
+	s := string(randomBytes(i, b))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		HashString(s)
+	}
+
 }


### PR DESCRIPTION
This PR makes the following changes:

1. Adds HashBytes implementation
   1. Allows for efficient hashing of existing byte slices without the need for large copy operations like `string(b)` to use the HashString implementation.  
1. Adds benchmarks for HashString and HashBytes, and a 3rd benchmark to illustrate the cost of converting existing byte slices to strings before using HashString.
1. Brings in the `#cgo` flags from another fork https://github.com/juxtin/gossdeep to support compilation on MacOS
   1. cc @juxtin
1. Adds a note to readme about setting `CGO_LDFLAGS_ALLOW` before running `go get`, as it will fail without it.

```
 ▲ ~/projects/gossdeep go test -bench=. -test.benchmem                                                                                                                         master :: 260d :: ⬡
goos: darwin
goarch: amd64
BenchmarkSSDeepString_1k-16             	  112908	      9654 ns/op	     112 B/op	       3 allocs/op
BenchmarkSSDeepString_10k-16            	   15261	     89598 ns/op	     128 B/op	       3 allocs/op
BenchmarkSSDeepString_100k-16           	    1250	    899034 ns/op	     112 B/op	       3 allocs/op
BenchmarkSSDeepString_250k-16           	     550	   2210747 ns/op	     112 B/op	       3 allocs/op
BenchmarkSSDeepString_500k-16           	     274	   4105095 ns/op	     128 B/op	       3 allocs/op
BenchmarkSSDeepConvertString_1k-16      	   59862	     20327 ns/op	    1232 B/op	       6 allocs/op
BenchmarkSSDeepConvertString_10k-16     	    7738	    167181 ns/op	   10480 B/op	       6 allocs/op
BenchmarkSSDeepConvertString_100k-16    	     654	   1941788 ns/op	  106772 B/op	       6 allocs/op
BenchmarkSSDeepConvertString_250k-16    	     264	   4131535 ns/op	  262352 B/op	       6 allocs/op
BenchmarkSSDeepConvertString_500k-16    	     150	   8151036 ns/op	  516306 B/op	       6 allocs/op
BenchmarkSSDeepBytes_1k-16              	  129466	      9550 ns/op	     112 B/op	       2 allocs/op
BenchmarkSSDeepBytes_10k-16             	   14758	     80550 ns/op	     112 B/op	       2 allocs/op
BenchmarkSSDeepBytes_100k-16            	    1300	    849152 ns/op	      96 B/op	       2 allocs/op
BenchmarkSSDeepBytes_250k-16            	     562	   1965892 ns/op	     112 B/op	       2 allocs/op
BenchmarkSSDeepBytes_500k-16            	     319	   3977398 ns/op	      80 B/op	       2 allocs/op
```