### PR TITLE
Add cgo directives for Darwin arm64 platform via homebrew

### DIFF
--- a/ssdeep.go
+++ b/ssdeep.go
@@ -2,6 +2,7 @@ package ssdeep
 
 /*
 #cgo !windows LDFLAGS:-L/usr/local/lib/ -lfuzzy -ldl -I/usr/local/include/
+#cgo darwin && arm64 LDFLAGS:-L/opt/homebrew/opt/ssdeep/lib
 #include <stdlib.h>
 #include <fuzzy.h>
 */

--- a/ssdeep.go
+++ b/ssdeep.go
@@ -1,8 +1,10 @@
 package ssdeep
 
 /*
-#cgo !windows LDFLAGS:-L/usr/local/lib/ -lfuzzy -ldl -I/usr/local/include/
+#cgo !windows LDFLAGS:-L/usr/local/lib/ -lfuzzy -ldl
+#cgo !windows CFLAGS:-I/usr/local/include/
 #cgo darwin && arm64 LDFLAGS:-L/opt/homebrew/opt/ssdeep/lib
+#cgo darwin && arm64 CFLAGS:-I/opt/homebrew/include
 #include <stdlib.h>
 #include <fuzzy.h>
 */


### PR DESCRIPTION
I had to add this line to get it to compile successfully on Apple Silicon. It's obviously specific to ssdeep being installed via home-brew, so not sure if this should actually be merged, but there probably aren't a ton of different ways people are installing ssdeep on their macs, so maybe it's an okay default.

At the very least maybe just seeing this can help someone else!